### PR TITLE
Add Universidad Rafael Landívar domain file.

### DIFF
--- a/correo.txt
+++ b/correo.txt
@@ -1,0 +1,2 @@
+Universidad Rafael Landívar
+URL


### PR DESCRIPTION
File generated via JetBrains form to validate academic emails from Universidad Rafael Landívar.

(domain: correo.url.edu.gt).